### PR TITLE
Make 'com.google.android.gms:play-services-gcm' use optional.

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -11,8 +11,6 @@ import android.provider.Settings.Secure;
 import android.webkit.WebSettings;
 import android.telephony.TelephonyManager;
 
-import com.google.android.gms.iid.InstanceID;
-
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -114,7 +112,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       e.printStackTrace();
     }
 
-    constants.put("instanceId", InstanceID.getInstance(this.reactContext).getId());
+    try {
+      if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
+        constants.put("instanceId", com.google.android.gms.iid.InstanceID.getInstance(this.reactContext).getId());
+      }
+    } catch (ClassNotFoundException e) {}
     constants.put("deviceName", deviceName);
     constants.put("systemName", "Android");
     constants.put("systemVersion", Build.VERSION.RELEASE);


### PR DESCRIPTION
With this option I can use the `react-native-device-info` and exclude `play-services-gcm` dependency.

Like this:

```gradle
dependencies {
    compile(project(':react-native-device-info')) {
        exclude group: 'com.google.android.gms', module: 'play-services-gcm'
    }
    ....
} 
```